### PR TITLE
Fixed URL formatting issue

### DIFF
--- a/src/main/java/com/icoderman/woocommerce/oauth/OAuthConfig.java
+++ b/src/main/java/com/icoderman/woocommerce/oauth/OAuthConfig.java
@@ -12,7 +12,7 @@ public final class OAuthConfig {
                 consumerSecret == null || consumerSecret.isEmpty()) {
             throw new IllegalArgumentException("All arguments are required");
         }
-        this.url = url;
+        this.url = url.endsWith("/") ? url.substring(0, url.lastIndexOf("/")) : url;
         this.consumerKey = consumerKey;
         this.consumerSecret = consumerSecret;
     }


### PR DESCRIPTION
That was super annoying when forgetting that only URL without "/" ending is acceptable. Now it can work with both.