### PR TITLE
Normalize trailing slash in store URLs

### DIFF
--- a/src/main/java/com/icoderman/woocommerce/oauth/OAuthConfig.java
+++ b/src/main/java/com/icoderman/woocommerce/oauth/OAuthConfig.java
@@ -12,7 +12,7 @@ public final class OAuthConfig {
                 consumerSecret == null || consumerSecret.isEmpty()) {
             throw new IllegalArgumentException("All arguments are required");
         }
-        this.url = url;
+        this.url = url.endsWith("/") ? url.substring(0, url.lastIndexOf("/")) : url;
         this.consumerKey = consumerKey;
         this.consumerSecret = consumerSecret;
     }

--- a/src/test/java/com/icoderman/woocommerce/oauth/OAuthConfigTest.java
+++ b/src/test/java/com/icoderman/woocommerce/oauth/OAuthConfigTest.java
@@ -1,0 +1,30 @@
+package com.icoderman.woocommerce.oauth;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class OAuthConfigTest {
+
+    @Test
+    public void removesOneTrailingSlashFromStoreUrl() {
+        OAuthConfig config = new OAuthConfig(
+                "https://store.example.com/",
+                "consumer-key",
+                "consumer-secret"
+        );
+
+        assertEquals("https://store.example.com", config.getUrl());
+    }
+
+    @Test
+    public void preservesStoreUrlWithoutTrailingSlash() {
+        OAuthConfig config = new OAuthConfig(
+                "https://store.example.com",
+                "consumer-key",
+                "consumer-secret"
+        );
+
+        assertEquals("https://store.example.com", config.getUrl());
+    }
+}


### PR DESCRIPTION
## Summary

- integrate the trailing-slash normalization contributed by @ekonopliov in #32
- preserve the contributor's original commit and authorship
- add focused regression coverage for URLs with and without a trailing slash

## Why

A store URL ending in `/` currently produces a double slash when the API path is appended. The contributor fix removes exactly one trailing slash during `OAuthConfig` construction.

## Compatibility

- no public API or binary signature changes
- no changes to OAuth signature generation
- URLs without a trailing slash are unchanged

## Verification

- `mvn clean verify -Dgpg.skip=true`
- 9 tests, 0 failures, 0 errors, 7 existing live-store tests skipped
- JAR, sources JAR, and Javadocs JAR built successfully

Credits @ekonopliov for the original fix in #32.