### PR TITLE
fix(deps): update Jackson to 2.18.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.18.9</jackson.version>
         <httpclient.version>4.5.14</httpclient.version>
         <junit.version>4.13.2</junit.version>
     </properties>


### PR DESCRIPTION
## Summary
- update the aligned Jackson Core, Databind, and Annotations version from 2.18.6 to 2.18.9
- remain on the conservative Jackson 2.18 maintenance line
- address the repository's 8 open Dependabot alerts (3 high, 5 moderate)

This clean current-`master` change supersedes Dependabot PRs #55, #57, and #58 without bringing pre-history-rewrite commits back into reachable history.

## Verification
- `mvn clean verify -Dgpg.skip=true`
- 9 tests, 0 failures/errors, 7 intentionally skipped live-store tests
- JAR, sources JAR, and Javadocs JAR built successfully
- dependency tree resolves `jackson-core`, `jackson-databind`, and `jackson-annotations` at 2.18.9

No production Java code or public API changes.