### PR TITLE
chore(build): update Maven and CI tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         java: ['8', '11', '17', '21']
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           distribution: temurin

--- a/pom.xml
+++ b/pom.xml
@@ -76,13 +76,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.1</version>
+                <version>3.15.0</version>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -128,7 +128,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.3.1</version>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
## Summary
- update Maven Compiler Plugin 3.14.1 → 3.15.0
- update Maven Source Plugin 3.3.1 → 3.4.0
- update Maven Release Plugin 3.1.1 → 3.3.1
- update `actions/checkout` v5 → v7

This clean current-`master` change supersedes Dependabot PRs #52, #53, #54, and #56 without bringing pre-history-rewrite commits back into reachable history.

## Verification
- `mvn clean verify -Dgpg.skip=true`
- 9 tests, 0 failures/errors, 7 intentionally skipped live-store tests
- JAR, sources JAR, and Javadocs JAR built successfully

No production Java code, dependency, or public API changes.