### PR TITLE
release: prepare 1.5.0 candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## Unreleased
+## 1.5.0 - 2026-08-11
 
 - Restored continuous integration across supported Java versions.
 - Removed embedded WooCommerce credentials from integration tests.
-- Updated maintained dependencies and build plugins.
+- Updated maintained dependencies and build plugins, including security fixes
+  for Jackson.
+- Normalized store URLs with a trailing slash, with regression coverage and
+  attribution to the original community contribution.
 - Updated project ownership, security, and contribution documentation.
+- Added a manually gated Central Publisher Portal release workflow.
 
 ## 1.4 - 2019-11-05
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A small Java wrapper for the WooCommerce REST API, originally released in 2016 a
 <dependency>
   <groupId>com.icoderman</groupId>
   <artifactId>wc-api-java</artifactId>
-  <version>1.4</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.icoderman</groupId>
     <artifactId>wc-api-java</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>1.5.0</version>
     <packaging>jar</packaging>
 
     <name>WooCommerce API Java Wrapper</name>
@@ -31,7 +31,7 @@
         <connection>scm:git:https://github.com/omandryk/wc-api-java.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/omandryk/wc-api-java.git</developerConnection>
         <url>https://github.com/omandryk/wc-api-java</url>
-        <tag>HEAD</tag>
+        <tag>v1.5.0</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
## Summary
- set the project version and SCM tag metadata for 1.5.0
- finalize the 1.5.0 changelog
- update the README dependency example

## Verification
- `mvn clean verify -Prelease -Dgpg.skip=true`
- 9 tests pass; 7 live-store integration tests remain intentionally skipped
- JAR, sources JAR, and Javadocs JAR build
- public API signatures match 1.4
- isolated Maven repository and blank consumer project resolve and execute 1.5.0

This PR does not publish to Maven Central, create a tag, or create a GitHub Release.