### PR TITLE
docs: define maintained legacy scope

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,29 @@
+# Maintenance policy
+
+`wc-api-java` 1.x is a maintained legacy client. Maintenance is deliberately bounded so existing users can keep resolving a stable artifact without implying feature parity with the current WooCommerce REST API.
+
+## In scope for 1.x
+
+- Security and maintained dependency updates compatible with Java 8.
+- Reproducible, backward-compatible bug fixes with regression tests.
+- CI, build, release, and documentation maintenance.
+- Clear answers about confirmed 1.x behavior and limitations.
+
+## Out of scope for 1.x
+
+- Breaking public API changes.
+- Comprehensive typed models or complete endpoint coverage.
+- New authentication architecture, including HTTPS Basic Authentication.
+- Automatically generated API clients or speculative fixes without reproducible evidence.
+
+These items require a separately evaluated major version. No 2.x roadmap is currently committed.
+
+## Quality and release gates
+
+Code changes require focused tests and a green Java 8, 11, 17, and 21 CI matrix. Authentication, signing, and request-encoding changes additionally require deterministic test vectors and WooCommerce compatibility evidence.
+
+Every Maven Central release requires a human-approved pull request, signed release candidate, independent consumer-resolution check, protected deployment approval, and manual Central publication. Automation may monitor, reproduce, and draft changes, but it may not comment, merge, tag, or publish autonomously.
+
+## Reporting issues
+
+Include the library version, Java version, WooCommerce version, endpoint, minimal reproduction, expected behavior, and sanitized response details. Never include consumer secrets, access tokens, order/customer data, or private store URLs.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 
 A small Java wrapper for the WooCommerce REST API, originally released in 2016 and distributed through Maven Central.
 
-> **Project revival:** version 1.4 is the latest published release. The 1.5 line restores maintenance, testing, and modern release infrastructure while preserving the existing API. Do not use unreleased snapshots in production.
+I originally created this library while building automation for a client's WordPress/WooCommerce store from a Java application. The project later found users of its own, even though it received very little maintenance for almost a decade.
+
+> **Maintenance release:** version 1.5.0 restores supported dependencies, CI, release infrastructure, and a tested community fix while preserving the 1.x public API. This is a maintained legacy client, not an official WooCommerce SDK.
+
+WooCommerce currently lists this repository among the third-party Java libraries in its [REST API documentation](https://developer.woocommerce.com/docs/apis/rest-api/). WooCommerce does not provide support for third-party libraries.
 
 ## Installation
 
@@ -42,6 +46,12 @@ Never commit WooCommerce credentials. Supply them through a secret manager or en
 - Legacy OAuth 1.0a request signing over HTTP
 
 The 1.x client does not implement WooCommerce HTTPS Basic Authentication. Use it only in a controlled environment until HTTPS-first authentication is available in a future major release.
+
+## Maintenance status
+
+The 1.x line receives bounded maintenance for dependency/security updates, reproducible bug fixes, CI compatibility, and documentation corrections. New endpoints, broad API modeling, and breaking changes are outside the 1.x scope.
+
+See [MAINTENANCE.md](MAINTENANCE.md) for the support policy and release gates.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- document the project origin and 1.5.0 maintenance posture
- clarify the third-party WooCommerce documentation listing without implying official support
- define bounded 1.x scope and human-gated release policy

## Verification

- `mvn clean verify`
- no production Java changes

WTX and other competing clients are intentionally not referenced.